### PR TITLE
Update top_ten.lua

### DIFF
--- a/lua/top_ten.lua
+++ b/lua/top_ten.lua
@@ -55,19 +55,15 @@ local get_res = client:make_jmap_call(
       },
       {
         "Email/get",
-        (function ()
-          -- this is a stupid workaround to inline args because we can't use
-          -- "#ids" as a key in the literal table syntax
-          local args = {}
-          args.accountId = account_id
-          args.properties = {"id", "subject", "receivedAt"}
-          args["#ids"] = {
-            resultOf = "a",
-            name = "Email/query",
-            path = "/ids/*",
-          }
-          return args
-        end)(),
+        {
+          accountId = account_id;
+          properties = {"id", "subject", "receivedAt"};
+          ["#ids"] = {
+            resultOf = "a";
+            name = "Email/query";
+            path = "/ids/*";
+          };
+        };
         "b",
       },
     },


### PR DESCRIPTION
The comment was incorrect, there is a syntax for inline definition of extended table keys.